### PR TITLE
Multi-Signature Wallet Smart Contract

### DIFF
--- a/maxprov/Clarinet.toml
+++ b/maxprov/Clarinet.toml
@@ -45,6 +45,11 @@ path = 'contracts/impact_report.clar'
 clarity_version = 2
 epoch = 2.5
 
+[contracts.multi_signature_wallet]
+path = 'contracts/multi_signature_wallet.clar'
+clarity_version = 2
+epoch = 2.5
+
 [contracts.tokenized_data]
 path = 'contracts/tokenized_data.clar'
 clarity_version = 2

--- a/maxprov/contracts/multi_signature_wallet.clar
+++ b/maxprov/contracts/multi_signature_wallet.clar
@@ -191,3 +191,21 @@
 )
 
 ;; Get current proposal counter
+(define-read-only (get-proposal-counter)
+    (var-get proposal-counter)
+)
+
+;; Get wallet balance
+(define-read-only (get-balance)
+    (stx-get-balance (as-contract tx-sender))
+)
+
+;; Private Functions
+
+;; Helper function for adding owners during initialization
+(define-private (add-owner-fold (owner principal) (prev-result bool))
+    (begin
+        (map-set owners owner true)
+        true
+    )
+)

--- a/maxprov/contracts/multi_signature_wallet.clar
+++ b/maxprov/contracts/multi_signature_wallet.clar
@@ -1,0 +1,193 @@
+;; Multi-Signature Wallet Smart Contract
+;; Allows multiple owners to collectively manage funds with approval requirements
+
+;; Constants
+(define-constant CONTRACT_OWNER tx-sender)
+(define-constant ERR_UNAUTHORIZED (err u100))
+(define-constant ERR_NOT_OWNER (err u101))
+(define-constant ERR_PROPOSAL_NOT_FOUND (err u102))
+(define-constant ERR_ALREADY_APPROVED (err u103))
+(define-constant ERR_INSUFFICIENT_APPROVALS (err u104))
+(define-constant ERR_PROPOSAL_EXECUTED (err u105))
+(define-constant ERR_INVALID_AMOUNT (err u106))
+(define-constant ERR_INSUFFICIENT_BALANCE (err u107))
+(define-constant ERR_OWNER_ALREADY_EXISTS (err u108))
+(define-constant ERR_INVALID_THRESHOLD (err u109))
+
+;; Data Variables
+(define-data-var required-approvals uint u2)
+(define-data-var proposal-counter uint u0)
+
+;; Data Maps
+;; Store wallet owners
+(define-map owners principal bool)
+
+;; Store withdrawal proposals
+(define-map proposals 
+    uint 
+    {
+        proposer: principal,
+        recipient: principal,
+        amount: uint,
+        approvals: uint,
+        executed: bool,
+        created-at: uint
+    }
+)
+
+;; Track who approved which proposal
+(define-map proposal-approvals {proposal-id: uint, approver: principal} bool)
+
+;; Public Functions
+
+;; Initialize the wallet with initial owners and required approvals
+(define-public (initialize (initial-owners (list 10 principal)) (threshold uint))
+    (begin
+        (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+        (asserts! (and (> threshold u0) (<= threshold (len initial-owners))) ERR_INVALID_THRESHOLD)
+        (var-set required-approvals threshold)
+        (fold add-owner-fold initial-owners true)
+        (ok true)
+    )
+)
+
+;; Add a new owner (requires existing owner)
+(define-public (add-owner (new-owner principal))
+    (begin
+        (asserts! (is-owner tx-sender) ERR_NOT_OWNER)
+        (asserts! (not (is-owner new-owner)) ERR_OWNER_ALREADY_EXISTS)
+        (map-set owners new-owner true)
+        (ok true)
+    )
+)
+
+;; Remove an owner (requires existing owner)
+(define-public (remove-owner (owner-to-remove principal))
+    (begin
+        (asserts! (is-owner tx-sender) ERR_NOT_OWNER)
+        (asserts! (is-owner owner-to-remove) ERR_NOT_OWNER)
+        (map-delete owners owner-to-remove)
+        (ok true)
+    )
+)
+
+;; Propose a withdrawal
+(define-public (propose-withdrawal (recipient principal) (amount uint))
+    (let 
+        (
+            (proposal-id (+ (var-get proposal-counter) u1))
+        )
+        (begin
+            (asserts! (is-owner tx-sender) ERR_NOT_OWNER)
+            (asserts! (> amount u0) ERR_INVALID_AMOUNT)
+            (asserts! (>= (stx-get-balance (as-contract tx-sender)) amount) ERR_INSUFFICIENT_BALANCE)
+            
+            ;; Create the proposal
+            (map-set proposals proposal-id
+                {
+                    proposer: tx-sender,
+                    recipient: recipient,
+                    amount: amount,
+                    approvals: u1,
+                    executed: false,
+                    created-at: burn-block-height
+                }
+            )
+            
+            ;; Automatically approve by proposer
+            (map-set proposal-approvals {proposal-id: proposal-id, approver: tx-sender} true)
+            
+            ;; Increment proposal counter
+            (var-set proposal-counter proposal-id)
+            
+            (ok proposal-id)
+        )
+    )
+)
+
+;; Approve a withdrawal proposal
+(define-public (approve-withdrawal (proposal-id uint))
+    (let 
+        (
+            (proposal (unwrap! (map-get? proposals proposal-id) ERR_PROPOSAL_NOT_FOUND))
+            (approval-key {proposal-id: proposal-id, approver: tx-sender})
+        )
+        (begin
+            (asserts! (is-owner tx-sender) ERR_NOT_OWNER)
+            (asserts! (not (get executed proposal)) ERR_PROPOSAL_EXECUTED)
+            (asserts! (is-none (map-get? proposal-approvals approval-key)) ERR_ALREADY_APPROVED)
+            
+            ;; Add approval
+            (map-set proposal-approvals approval-key true)
+            
+            ;; Update proposal with incremented approvals
+            (map-set proposals proposal-id
+                (merge proposal {approvals: (+ (get approvals proposal) u1)})
+            )
+            
+            (ok true)
+        )
+    )
+)
+
+;; Execute withdrawal after sufficient approvals
+(define-public (execute-withdrawal (proposal-id uint))
+    (let 
+        (
+            (proposal (unwrap! (map-get? proposals proposal-id) ERR_PROPOSAL_NOT_FOUND))
+        )
+        (begin
+            (asserts! (is-owner tx-sender) ERR_NOT_OWNER)
+            (asserts! (not (get executed proposal)) ERR_PROPOSAL_EXECUTED)
+            (asserts! (>= (get approvals proposal) (var-get required-approvals)) ERR_INSUFFICIENT_APPROVALS)
+            (asserts! (>= (stx-get-balance (as-contract tx-sender)) (get amount proposal)) ERR_INSUFFICIENT_BALANCE)
+            
+            ;; Mark as executed
+            (map-set proposals proposal-id
+                (merge proposal {executed: true})
+            )
+            
+            ;; Transfer STX
+            (as-contract (stx-transfer? (get amount proposal) tx-sender (get recipient proposal)))
+        )
+    )
+)
+
+;; Deposit STX to the wallet
+(define-public (deposit (amount uint))
+    (stx-transfer? amount tx-sender (as-contract tx-sender))
+)
+
+;; Update required approvals threshold
+(define-public (set-required-approvals (new-threshold uint))
+    (begin
+        (asserts! (is-owner tx-sender) ERR_NOT_OWNER)
+        (asserts! (> new-threshold u0) ERR_INVALID_THRESHOLD)
+        (var-set required-approvals new-threshold)
+        (ok true)
+    )
+)
+
+;; Read-only Functions
+
+;; Check if an address is an owner
+(define-read-only (is-owner (address principal))
+    (default-to false (map-get? owners address))
+)
+
+;; Get proposal details
+(define-read-only (get-proposal (proposal-id uint))
+    (map-get? proposals proposal-id)
+)
+
+;; Check if someone approved a proposal
+(define-read-only (has-approved (proposal-id uint) (approver principal))
+    (default-to false (map-get? proposal-approvals {proposal-id: proposal-id, approver: approver}))
+)
+
+;; Get required approvals threshold
+(define-read-only (get-required-approvals)
+    (var-get required-approvals)
+)
+
+;; Get current proposal counter

--- a/maxprov/tests/multi_signature_wallet.test.ts
+++ b/maxprov/tests/multi_signature_wallet.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Multi-Signature Wallet (Clarity) — README</h1>
<p>A secure, on-chain STX multisig wallet that lets multiple owners collectively authorize withdrawals via proposals and approvals. Includes adjustable approval thresholds, owner management, and fully queryable state for audits.</p>
<hr>
<h2>Overview</h2>
<ul>
<li>
<p><strong>Language:</strong> Clarity (Stacks)</p>
</li>
<li>
<p><strong>Core idea:</strong> Funds sit in the contract account. Any withdrawal must be <strong>proposed</strong> by an owner and <strong>approved</strong> by a quorum of owners (the <strong>required approvals</strong> threshold) before it can be <strong>executed</strong>.</p>
</li>
<li>
<p><strong>Out of the box:</strong> initialization with a set of owners and a threshold; deposit, propose, approve, execute; add/remove owners; view helpers for balance, proposals, and approvals.</p>
</li>
</ul>
<hr>
<h2>Key Features</h2>
<ul>
<li>
<p>✅ <strong>Quorum-gated withdrawals</strong> with proposer auto-approval</p>
</li>
<li>
<p>✅ <strong>Adjustable threshold</strong> (<code inline="">required-approvals</code>)</p>
</li>
<li>
<p>✅ <strong>Owner management</strong> (add/remove)</p>
</li>
<li>
<p>✅ <strong>Replay/duplicate prevention</strong> (one approval per owner per proposal)</p>
</li>
<li>
<p>✅ <strong>Readable state</strong> for dApp UIs and audits</p>
</li>
</ul>
<hr>
<h2>Data Model</h2>
<h3>Data Vars</h3>
<ul>
<li>
<p><code inline="">required-approvals : uint</code> — number of distinct owner approvals needed (default <code inline="">u2</code>).</p>
</li>
<li>
<p><code inline="">proposal-counter : uint</code> — monotonically increasing ID for proposals.</p>
</li>
</ul>
<h3>Maps</h3>
<ul>
<li>
<p><code inline="">owners: principal =&gt; bool</code> — set of wallet owners.</p>
</li>
<li>
<p><code inline="">proposals: uint =&gt; { proposer, recipient, amount, approvals, executed, created-at }</code></p>
</li>
<li>
<p><code inline="">proposal-approvals: { proposal-id: uint, approver: principal } =&gt; bool</code> — records who has approved what.</p>
</li>
</ul>
<blockquote>
<p><strong>Balance source:</strong> Wallet STX is held by the <strong>contract principal</strong>, i.e. <code inline="">(as-contract tx-sender)</code> inside read-only queries.</p>
</blockquote>
<hr>
<h2>Errors</h2>

Code | Const | Meaning
-- | -- | --
u100 | ERR_UNAUTHORIZED | Caller isn’t the contract owner where required (init).
u101 | ERR_NOT_OWNER | Caller or referenced principal isn’t an owner when required.
u102 | ERR_PROPOSAL_NOT_FOUND | Proposal ID doesn’t exist.
u103 | ERR_ALREADY_APPROVED | Caller already approved this proposal.
u104 | ERR_INSUFFICIENT_APPROVALS | Trying to execute without enough approvals.
u105 | ERR_PROPOSAL_EXECUTED | Proposal already executed.
u106 | ERR_INVALID_AMOUNT | Amount is u0 or invalid.
u107 | ERR_INSUFFICIENT_BALANCE | Contract lacks funds for the transfer.
u108 | ERR_OWNER_ALREADY_EXISTS | Attempt to add an existing owner.
u109 | ERR_INVALID_THRESHOLD | Threshold u0 or exceeds initial owner count at init.


<hr>
<h2>Contract Lifecycle &amp; Permissions</h2>
<ul>
<li>
<p><strong>Deployment:</strong> <code inline="">CONTRACT_OWNER</code> is set to the deployer (captured at publish time).</p>
</li>
<li>
<p><strong>Initialization:</strong> Only <code inline="">CONTRACT_OWNER</code> can call <code inline="">initialize</code>. After that, owners manage day-to-day operations.</p>
</li>
<li>
<p><strong>Owners:</strong> Any principal with <code inline="">owners[p] == true</code>.</p>
</li>
</ul>
<hr>
<h2>Public Entry Points</h2>
<h3>1) Initialize</h3>
<pre><code>(define-public (initialize (initial-owners (list 10 principal)) (threshold uint)) -&gt; (response bool uint))
</code></pre>
<ul>
<li>
<p><strong>Who:</strong> <code inline="">CONTRACT_OWNER</code> only.</p>
</li>
<li>
<p><strong>Effect:</strong> Sets <code inline="">required-approvals = threshold</code>; adds each <code inline="">initial-owners</code> to <code inline="">owners</code>.</p>
</li>
<li>
<p><strong>Checks:</strong> <code inline="">threshold &gt; u0</code> and <code inline="">threshold &lt;= len(initial-owners)</code>.</p>
</li>
<li>
<p><strong>Returns:</strong> <code inline="">(ok true)</code>.</p>
</li>
</ul>
<h3>2) Add Owner</h3>
<pre><code>(define-public (add-owner (new-owner principal)) -&gt; (response bool uint))
</code></pre>
<ul>
<li>
<p><strong>Who:</strong> Any current owner.</p>
</li>
<li>
<p><strong>Effect:</strong> Adds <code inline="">new-owner</code> to <code inline="">owners</code>.</p>
</li>
<li>
<p><strong>Checks:</strong> Fails if <code inline="">new-owner</code> already an owner.</p>
</li>
</ul>
<h3>3) Remove Owner</h3>
<pre><code>(define-public (remove-owner (owner-to-remove principal)) -&gt; (response bool uint))
</code></pre>
<ul>
<li>
<p><strong>Who:</strong> Any current owner.</p>
</li>
<li>
<p><strong>Effect:</strong> Removes <code inline="">owner-to-remove</code> from <code inline="">owners</code>.</p>
</li>
<li>
<p><strong>Note:</strong> Existing proposals/approvals are <strong>not</strong> rewritten; see “Design Notes”.</p>
</li>
</ul>
<h3>4) Deposit</h3>
<pre><code>(define-public (deposit (amount uint)) -&gt; (response bool uint))
</code></pre>
<ul>
<li>
<p><strong>Effect:</strong> Transfers <code inline="">amount</code> STX from caller to the contract.</p>
</li>
</ul>
<h3>5) Propose Withdrawal</h3>
<pre><code>(define-public (propose-withdrawal (recipient principal) (amount uint)) -&gt; (response uint uint))
</code></pre>
<ul>
<li>
<p><strong>Who:</strong> Any owner.</p>
</li>
<li>
<p><strong>Effect:</strong> Creates proposal <code inline="">proposal-id = proposal-counter + 1</code> with:</p>
<ul>
<li>
<p><code inline="">approvals = u1</code> (proposer auto-approves),</p>
</li>
<li>
<p><code inline="">executed = false</code>,</p>
</li>
<li>
<p><code inline="">created-at = burn-block-height</code>.</p>
</li>
</ul>
</li>
<li>
<p><strong>Checks:</strong> <code inline="">amount &gt; u0</code>, contract balance ≥ <code inline="">amount</code>.</p>
</li>
<li>
<p><strong>Returns:</strong> <code inline="">(ok proposal-id)</code>.</p>
</li>
</ul>
<h3>6) Approve Withdrawal</h3>
<pre><code>(define-public (approve-withdrawal (proposal-id uint)) -&gt; (response bool uint))
</code></pre>
<ul>
<li>
<p><strong>Who:</strong> Any owner.</p>
</li>
<li>
<p><strong>Effect:</strong> Records one approval for caller; increments proposal’s <code inline="">approvals</code>.</p>
</li>
<li>
<p><strong>Checks:</strong> Proposal exists, not executed, caller hasn’t approved yet.</p>
</li>
</ul>
<h3>7) Execute Withdrawal</h3>
<pre><code>(define-public (execute-withdrawal (proposal-id uint)) -&gt; (response bool uint))
</code></pre>
<ul>
<li>
<p><strong>Who:</strong> Any owner.</p>
</li>
<li>
<p><strong>Effect:</strong> If <code inline="">approvals &gt;= required-approvals</code>, marks proposal <code inline="">executed = true</code> and transfers STX from the contract to the proposal’s <code inline="">recipient</code>.</p>
</li>
<li>
<p><strong>Checks:</strong> Proposal exists, not executed, enough approvals, contract has funds.</p>
</li>
</ul>
<h3>8) Set Required Approvals</h3>
<pre><code>(define-public (set-required-approvals (new-threshold uint)) -&gt; (response bool uint))
</code></pre>
<ul>
<li>
<p><strong>Who:</strong> Any owner.</p>
</li>
<li>
<p><strong>Effect:</strong> Updates <code inline="">required-approvals</code>.</p>
</li>
<li>
<p><strong>Checks:</strong> <code inline="">new-threshold &gt; u0</code>. <em>(No upper bound enforced here; see “Design Notes”.)</em></p>
</li>
</ul>
<hr>
<h2>Read-Only Helpers</h2>
<ul>
<li>
<p><code inline="">(is-owner (address principal)) -&gt; bool</code></p>
</li>
<li>
<p><code inline="">(get-proposal (proposal-id uint)) -&gt; (optional { ... })</code></p>
</li>
<li>
<p><code inline="">(has-approved (proposal-id uint) (approver principal)) -&gt; bool</code></p>
</li>
<li>
<p><code inline="">(get-required-approvals) -&gt; uint</code></p>
</li>
<li>
<p><code inline="">(get-proposal-counter) -&gt; uint</code></p>
</li>
<li>
<p><code inline="">(get-balance) -&gt; uint</code> — STX balance of the contract.</p>
</li>
</ul>
<hr>
<h2>Typical Workflow</h2>
<ol>
<li>
<p><strong>Fund the wallet</strong></p>
<ul>
<li>
<p>Anyone can call <code inline="">deposit</code>.</p>
</li>
</ul>
</li>
<li>
<p><strong>Create a proposal</strong></p>
<ul>
<li>
<p>An owner calls <code inline="">propose-withdrawal(recipient, amount)</code> → gets <code inline="">proposal-id</code>.</p>
</li>
<li>
<p>Proposer counts as the first approval.</p>
</li>
</ul>
</li>
<li>
<p><strong>Collect approvals</strong></p>
<ul>
<li>
<p>Other owners call <code inline="">approve-withdrawal(proposal-id)</code>.</p>
</li>
</ul>
</li>
<li>
<p><strong>Execute</strong></p>
<ul>
<li>
<p>Any owner calls <code inline="">execute-withdrawal(proposal-id)</code> once approvals ≥ threshold.</p>
</li>
</ul>
</li>
</ol>
<hr>
<h2>Example Calls (pseudocode)</h2>
<pre><code class="language-clarity">;; After deploy, the deployer initializes:
(contract-call? .multisig initialize (list tx-sender 'SP2... 'SP3...) u2)

;; Deposit 10_000_000 microSTX (0.01 STX example)
(contract-call? .multisig deposit u10000000)

;; Propose a payout
(define-constant pid (unwrap-panic (contract-call? .multisig propose-withdrawal 'SPrecipient... u5000000)))

;; Second owner approves
(contract-call? .multisig approve-withdrawal pid)

;; Execute once approvals ≥ required-approvals
(contract-call? .multisig execute-withdrawal pid)
</code></pre>
<hr>
<h2>Design Notes &amp; Caveats</h2>
<ul>
<li>
<p><strong>Initialization authority:</strong> Only the <code inline="">CONTRACT_OWNER</code> (deployer captured at publish time) can call <code inline="">initialize</code>. All other operations are gated by <strong>owners</strong>.</p>
</li>
<li>
<p><strong>Threshold management:</strong></p>
<ul>
<li>
<p>At <strong>init</strong>, <code inline="">threshold</code> must be ≤ number of <code inline="">initial-owners</code>.</p>
</li>
<li>
<p><strong>Later</strong>, <code inline="">set-required-approvals</code> only enforces <code inline="">&gt; u0</code> — it does <strong>not</strong> ensure the threshold ≤ current owner count. If you reduce owners or raise the threshold too high, the wallet could become <strong>unexecutable</strong>. Consider adding a guard or operational playbook.</p>
</li>
</ul>
</li>
<li>
<p><strong>Owner removal:</strong></p>
<ul>
<li>
<p>Existing proposals are <strong>not</strong> re-computed when owners are removed. Approvals already cast remain counted; removed owners can’t cast new approvals.</p>
</li>
</ul>
</li>
<li>
<p><strong>Proposal lifetime:</strong> No expiry or cancellation mechanism is included. You may want to add a cancel function (by proposer or by quorum) and/or an expiry based on <code inline="">burn-block-height</code>.</p>
</li>
<li>
<p><strong>Asset type:</strong> This contract manages <strong>STX only</strong> (via <code inline="">stx-transfer?</code>). To support SIP-010 tokens, add analogous proposal/execute flows per token.</p>
</li>
<li>
<p><strong>Reentrancy:</strong> Clarity is non-reentrant; still, the contract marks a proposal executed <strong>before</strong> transferring funds, avoiding double-spend on retry.</p>
</li>
<li>
<p><strong>Idempotency:</strong> Execute checks <code inline="">executed = false</code>; retries after a failed transfer attempt won’t double-spend.</p>
</li>
</ul>
<hr>
<h2>Testing Checklist</h2>
<ul>
<li>
<p>✅ Init rejections when: non-owner caller; <code inline="">threshold = u0</code>; <code inline="">threshold &gt; len(initial-owners)</code>.</p>
</li>
<li>
<p>✅ Deposit succeeds and updates <code inline="">get-balance</code>.</p>
</li>
<li>
<p>✅ Propose fails if <code inline="">amount = u0</code> or contract balance insufficient.</p>
</li>
<li>
<p>✅ Approval fails if already approved or proposal executed.</p>
</li>
<li>
<p>✅ Execute fails if approvals &lt; threshold or funds insufficient; succeeds otherwise and flips <code inline="">executed</code>.</p>
</li>
<li>
<p>✅ Owner add/remove behavior around proposals and ability to reach quorum.</p>
</li>
<li>
<p>✅ Threshold changes don’t brick the wallet operationally.</p>
</li>
</ul>
<hr>
<h2>Suggested Extensions</h2>
<ul>
<li>
<p>🧩 <strong>Cancel proposal</strong> (by proposer; or by ≥X owners)</p>
</li>
<li>
<p>⏳ <strong>Expiry</strong> / stale proposal cleanup</p>
</li>
<li>
<p>🪪 <strong>Role separation</strong> (e.g., guardians vs. proposers)</p>
</li>
<li>
<p>🔔 <strong>Events</strong> via print logs for off-chain indexers</p>
</li>
<li>
<p>🪙 <strong>Token support</strong> (SIP-010)</p>
</li>
<li>
<p>🧮 <strong>Upper-bound threshold check</strong> on <code inline="">set-required-approvals</code> relative to current owner count</p>
</li>
</ul>
<hr>
<h2>Security Considerations</h2>
<ul>
<li>
<p><strong>Multisig hygiene:</strong> Keep owner keys independent and securely stored.</p>
</li>
<li>
<p><strong>Operational safety:</strong> When removing owners or updating the threshold, ensure that at least one viable quorum remains.</p>
</li>
<li>
<p><strong>Funds availability:</strong> Execute re-checks the contract balance; ensure no competing proposals will drain funds needed for a pending one.</p>
</li>
<li>
<p><strong>Auditing:</strong> UIs/indexers should rely on <code inline="">get-proposal</code>, <code inline="">has-approved</code>, and <code inline="">print</code> logs (if added) to render accurate state.</p>
</li>
</ul>
<hr>
<h2>Deployment Notes</h2>
<ul>
<li>
<p>Publish the contract, then immediately call <code inline="">initialize(initial-owners, threshold)</code>.</p>
</li>
<li>
<p>Consider seeding funds only <strong>after</strong> initialization is confirmed.</p>
</li>
<li>
<p>Pin down owner addresses and quorum policy in team docs to avoid accidental lock-ups.</p>
</li>
</ul>
<hr>
<h3>License</h3>
<p>Add your preferred license (e.g., MIT/Apache-2.0) and attribution here.</p>
<hr>
</body></html><!--EndFragment-->
</body>
</html>